### PR TITLE
Increase available disk space by removing unnecessary files

### DIFF
--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -37,9 +37,9 @@ jobs:
     - name: Reclaim disk space
       run: |
         df -h
-        rm -rf /usr/local/lib/android
-        rm -rf /opt/hostedtoolcache/CodeQL
-        rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/local/.ghcup
         df -h
 
     - uses: actions/checkout@v3

--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -34,6 +34,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@v7
+      with:
+        root-reserve-mb: 512
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
     - uses: actions/checkout@v3
       with:
         submodules: 'recursive'

--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -34,16 +34,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Maximize build space
-      uses: easimon/maximize-build-space@v7
-      with:
-        root-reserve-mb: 512
-        swap-size-mb: 1024
-        remove-dotnet: 'true'
-        remove-android: 'true'
-        remove-haskell: 'true'
-        remove-codeql: 'true'
-        remove-docker-images: 'true'
+    - name: Reclaim disk space
+      run: |
+        df -h
+        rm -rf /usr/local/lib/android
+        rm -rf /opt/hostedtoolcache/CodeQL
+        rm -rf /usr/local/.ghcup
+        df -h
+
     - uses: actions/checkout@v3
       with:
         submodules: 'recursive'


### PR DESCRIPTION
https://github.com/mlc-ai/package/pull/35 suggests that we only have 25GB space available on disk which is not enough to build manylinux wheels that ships CUDA.

Following the strategy in [maximize-build-disk-space](https://github.com/marketplace/actions/maximize-build-disk-space), we remove unnecessary packages installed on GitHub runners, [This runner log](https://github.com/mlc-ai/package/actions/runs/5595320767/jobs/10231078899?pr=35) shows the largest installed packages:
```
36933148	/usr
23267068	/usr/local
14192800	/usr/local/lib
12879584	/opt
12631624	/usr/local/lib/android
12631620	/usr/local/lib/android/sdk
10513088	/opt/hostedtoolcache
7095260	/opt/hostedtoolcache/CodeQL
6976296	/usr/lib
6259160	/usr/local/lib/android/sdk/ndk
5303196	/usr/share
4917316	/usr/local/.ghcup
4841796	/usr/local/.ghcup/ghc
4283412	/opt/hostedtoolcache/CodeQL/2.13.5
4283408	/opt/hostedtoolcache/CodeQL/2.13.5/x64
4283404	/opt/hostedtoolcache/CodeQL/2.13.5/x64/codeql
4194332	/mnt
4194308	/mnt/swapfile
3003320	/usr/local/lib/android/sdk/build-tools
```

Android SDK is around 12.6GB, CodeQL takes 7.1GB and GHC takes 4.8GB, but these packages have nothing to do with our wheel building. By removing these packages we reclaim ~23GB disk space (available disk from 25GB to 48GB), which should be enough for building manylinux wheels inside docker container.

This is a hack, and in the future, we might [buy larger runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners) or switch to self-hosted runners for building manylinux wheels.