### PR TITLE
Decouple win/mac wheel build

### DIFF
--- a/.github/workflows/wheel_mac_nightly.yaml
+++ b/.github/workflows/wheel_mac_nightly.yaml
@@ -1,0 +1,141 @@
+# GH actions.
+name: Wheel-Mac-X86/64-Nightly
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * *' # 6 AM UTC
+
+jobs:
+  Build:
+    strategy:
+      matrix:
+        pkg: ['mlc-ai-nightly']
+        mlc-chat-pkg: ['mlc-chat-nightly']
+
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: 'bash -l {0}'
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - name: Setup script env
+      run: |
+        mv conda/tvm-unity/build-environment.yaml 3rdparty/tlcpack/conda/build-environment.yaml
+        rm -rf conda
+        ln -s 3rdparty/tlcpack/conda conda
+    - name: Checkout source
+      run: |
+        git clone https://github.com/mlc-ai/relax tvm --recursive
+        git clone https://github.com/mlc-ai/mlc-llm mlc-llm --recursive
+    - name: Sync Package
+      run: |
+        python3 scripts/sync_package.py --package tvm --package-name ${{ matrix.pkg }} --revision origin/mlc --skip-checkout --skip-conda
+        python3 scripts/sync_package.py --package mlc-llm --package-name ${{ matrix.mlc-chat-pkg }} --revision origin/main --skip-checkout --skip-conda
+    # Use conda for LLVM dep
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: tlcpack-build
+        channel-priority: strict
+        environment-file: conda/build-environment.yaml
+        auto-activate-base: false
+    - name: Conda info
+      run: |
+        conda info
+        conda list
+        python --version
+    - name: Build@MacOS
+      run: >-
+        scripts/build_mlc_ai_lib_osx.sh
+    - name: Build MLC-Chat@MacOS
+      run: >-
+        scripts/build_mlc_chat_lib_osx.sh
+    # Build wheel for three python versions
+    - name: Setup@Py38
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: build-Py38
+        python-version: 3.8
+        auto-activate-base: false
+    - name: Wheel-Build@Py38
+      run: |
+        python --version
+        python -m pip install setuptools Cython wheel
+        cd tvm/python
+        python setup.py bdist_wheel
+    - name: Wheel-Build-MLC-Chat@Py38
+      run: |
+        python --version
+        cd mlc-llm/python
+        python setup.py bdist_wheel
+    - name: Setup@Py39
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: build-Py39
+        python-version: 3.9
+        auto-activate-base: false
+    - name: Wheel-Build@Py39
+      run: |
+        python --version
+        python -m pip install setuptools Cython wheel
+        cd tvm/python
+        python setup.py bdist_wheel
+    - name: Wheel-Build-MLC-Chat@Py39
+      run: |
+        python --version
+        cd mlc-llm/python
+        python setup.py bdist_wheel
+    - name: Setup@Py310
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: build-Py310
+        python-version: '3.10'
+        auto-activate-base: false
+    - name: Wheel-Build@Py310
+      run: |
+        python --version
+        python -m pip install setuptools Cython wheel
+        cd tvm/python
+        python setup.py bdist_wheel
+    - name: Wheel-Build-MLC-Chat@Py310
+      run: |
+        python --version
+        cd mlc-llm/python
+        python setup.py bdist_wheel
+    - name: Setup@Py311
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: build-Py311
+        python-version: '3.11'
+        auto-activate-base: false
+    - name: Wheel-Build@Py311
+      run: |
+        python --version
+        python -m pip install setuptools Cython wheel
+        cd tvm/python
+        python setup.py bdist_wheel
+    - name: Wheel-Build-MLC-Chat@Py311
+      run: |
+        python --version
+        cd mlc-llm/python
+        python setup.py bdist_wheel
+    # Use system python instead of conda for upload
+    - name: Wheel-Deploy
+      if: github.ref == 'refs/heads/main'
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.MLC_GITHUB_TOKEN }}
+      with:
+        files: |
+          tvm/python/dist/*.whl
+          mlc-llm/python/dist/*.whl
+        tag_name: v0.9.dev0
+        prerelease: true

--- a/.github/workflows/wheel_win_nightly.yaml
+++ b/.github/workflows/wheel_win_nightly.yaml
@@ -1,5 +1,5 @@
 # GH actions.
-name: Wheel-WinMac-Nightly
+name: Wheel-Windows-Nightly
 
 on:
   push:
@@ -17,16 +17,11 @@ jobs:
       matrix:
         pkg: ['mlc-ai-nightly']
         mlc-chat-pkg: ['mlc-chat-nightly']
-        sys:
-          - os: macos-latest
-            shell: 'bash -l {0}'
-          - os: windows-latest
-            shell: 'cmd /C call {0}'
 
-    runs-on: ${{ matrix.sys.os }}
+    runs-on: windows-latest
     defaults:
       run:
-        shell: ${{ matrix.sys.shell }}
+        shell: 'cmd /C call {0}'
 
     steps:
     - uses: actions/checkout@v3
@@ -57,20 +52,10 @@ jobs:
         conda info
         conda list
         python --version
-    - name: Build@MacOS
-      if: startsWith(matrix.sys.os, 'macOS')
-      run: >-
-        scripts/build_mlc_ai_lib_osx.sh
-    - name: Build MLC-Chat@MacOS
-      if: startsWith(matrix.sys.os, 'macOS')
-      run: >-
-        scripts/build_mlc_chat_lib_osx.sh
     - name: Build@Win
-      if: startsWith(matrix.sys.os, 'windows')
       run: >-
         scripts/build_mlc_ai_lib_win.bat
     - name: Build-Check@Win
-      if: startsWith(matrix.sys.os, 'windows')
       run: |
         IF EXIST "tvm\build\Release\tvm_runtime.dll" (
           echo tvm_runtime.dll exists.
@@ -85,7 +70,6 @@ jobs:
           exit /b 1
         )
     - name: Build MLC-Chat@Win
-      if: startsWith(matrix.sys.os, 'windows')
       run: >-
         scripts/build_mlc_chat_lib_win.bat
     # Build wheel for three python versions


### PR DESCRIPTION
Duplicate of #37 but pulled from `mlc-ai/decouple-win-mac` to enable self-hosted runners.

The Windows build should have been fixed in https://github.com/mlc-ai/relax/pull/271, kudos to @junrushao .
The Mac x86-64 is still buggy and is waiting for Cython 3 compatibility fix in TVM mainline.

Let's merge this PR and make windows wheel work first.
