### PR TITLE
Deprecate CLI nightly builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,5 @@
 [![Wheel-Mac-X86/64-Nightly](https://github.com/mlc-ai/package/actions/workflows/wheel_mac_nightly.yaml/badge.svg)](https://github.com/mlc-ai/package/actions/workflows/wheel_mac_nightly.yaml)
 [![Wheel-Windows-Nightly](https://github.com/mlc-ai/package/actions/workflows/wheel_win_nightly.yaml/badge.svg)](https://github.com/mlc-ai/package/actions/workflows/wheel_win_nightly.yaml)
 [![Wheel-Manylinux-Nightly](https://github.com/mlc-ai/package/actions/workflows/wheel_manylinux_nightly.yaml/badge.svg)](https://github.com/mlc-ai/package/actions/workflows/wheel_manylinux_nightly.yaml)
-[![MLC-Chat-CLI-Conda-Nightly](https://github.com/mlc-ai/package/actions/workflows/llm_conda_nightly.yaml/badge.svg)](https://github.com/mlc-ai/package/actions/workflows/llm_conda_nightly.yaml)
-[![MLC-Chat-CLI-Conda-Nightly-Apple-Silicon-Mac](https://github.com/mlc-ai/package/actions/workflows/llm_conda_nightly_apple_silicon_mac.yaml/badge.svg)](https://github.com/mlc-ai/package/actions/workflows/llm_conda_nightly_apple_silicon_mac.yaml)
 [![Prune-Nightly](https://github.com/mlc-ai/package/actions/workflows/prune_nightly.yaml/badge.svg)](https://github.com/mlc-ai/package/actions/workflows/prune_nightly.yaml)
 


### PR DESCRIPTION
This PR removes the CLI build badges, as the MLC LLM CLI has been deprecated.

The workflow yaml files are kept for future reference, since it suffices to disable the workflow manually on GitHub.