### PR TITLE
Deprecate CUDA 11.7/11.8 wheel build for thrust support

### DIFF
--- a/.github/workflows/wheel_applesiliconmac_nightly.yaml
+++ b/.github/workflows/wheel_applesiliconmac_nightly.yaml
@@ -35,7 +35,7 @@ jobs:
         ln -s 3rdparty/tlcpack/conda conda
     - name: Checkout source
       run: |
-        git clone https://github.com/mlc-ai/relax tvm --recursive --single-branch --branch mlc
+        git clone https://github.com/mlc-ai/relax tvm --recursive --single-branch --branch ${{ matrix.pkg_kind == 'stable' && 'v0.15.1' || 'mlc' }}
         git clone https://github.com/mlc-ai/mlc-llm mlc-llm --recursive --single-branch --branch main
     - name: Build mlc-ai @ 3.8
       env:

--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -21,10 +21,6 @@ jobs:
         config:
           - gpu: 'none'
             image: 'mlcaidev/package-cpu:7dc84a7'
-          - gpu: 'cuda-11.7'
-            image: 'mlcaidev/package-cu117:7dc84a7'
-          - gpu: 'cuda-11.8'
-            image: 'mlcaidev/package-cu118:7dc84a7'
           - gpu: 'cuda-12.1'
             image: 'mlcaidev/package-cu121:7dc84a7'
           - gpu: 'cuda-12.2'


### PR DESCRIPTION
Right now TVM contrib thrust only is not compatible with CUDA 11.7/11.8. To enable building wheel with thrust by default, this PR deprecates the wheel build of 11.7/11.8.